### PR TITLE
Add Date Support

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -45,6 +45,7 @@ The data types available are:
 * @integer@ or an array of @integers@
 * @float@ or an array of @floats@
 * @boolean@ or an array of @booleans@ (options are: &lt;empty&gt;, @0@ or @1@)
+* @date@ or an array of @dates@ (RFC2822 or ISO8601)
 
 There are two separators which csonv.js handles:
 

--- a/src/csonv.js
+++ b/src/csonv.js
@@ -37,6 +37,9 @@ Csonv = (function(undefined) {
       "boolean": function(value) {
         return parseInt(value, 10) == 1;
       },
+      "date": function(value) {
+        return new Date(value);
+      },
       "strings": function(value) {
         return n("string", value);
       },
@@ -49,6 +52,10 @@ Csonv = (function(undefined) {
       "booleans": function(value) {
         return n("boolean", value);
       },
+      "dates": function(value) {
+        return n("date", value);
+      },
+
       "relation": function(ids, type, url, id) {
         var assoc     = type.split(":");
         var assoc_url = resolvePath(url, assoc[0] + ".csv");


### PR DESCRIPTION
This pull request adds date fields to supported data types using the "new Date(dateString)" constructor which allows RFC2822 dates ("Wed, 21 Mar 2012 00:00:00 +0000") as of ECMAScript 1.0, and ISO8601 dates ("2012-03-21T21:37:02-04:00") as of ECMAScript 5.0.

References:
- https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
- https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/parse
